### PR TITLE
Borders around the Hotspot callout target Functionality

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "flutter_hotspot",
+            "request": "launch",
+            "type": "dart",
+            "program": "example/lib/main.dart",
+        },
+    ]
+}

--- a/example/ios/Runner/AppDelegate.swift
+++ b/example/ios/Runner/AppDelegate.swift
@@ -1,7 +1,7 @@
 import UIKit
 import Flutter
 
-@UIApplicationMain
+@main
 @objc class AppDelegate: FlutterAppDelegate {
   override func application(
     _ application: UIApplication,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -21,8 +21,12 @@ class MyApp extends StatelessWidget {
         brightness: Brightness.dark,
         colorSchemeSeed: Colors.purple,
       ),
-      home: const HotspotProvider(
-        child: MyHomePage(title: 'Hotspot Demo Home Page'),
+      home: HotspotProvider(
+        hotspotShapeBorder: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(100),
+          side: const BorderSide(color: Colors.blue, width: 2),
+        ),
+        child: const MyHomePage(title: 'Hotspot Demo Home Page'),
       ),
     );
   }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -67,6 +67,10 @@ class _MyHomePageState extends State<MyHomePage> {
           order: 1,
           title: "Let's get started!",
           text: "We're going to give you an example tour with hotspot",
+          hotspotShape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(1),
+            side: const BorderSide(color: Colors.red, width: 2),
+          ),
         ),
         actions: [
           IconButton(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -26,6 +26,9 @@ class MyApp extends StatelessWidget {
           borderRadius: BorderRadius.circular(100),
           side: const BorderSide(color: Colors.blue, width: 2),
         ),
+        autoScroll: true, // Enable auto scrolling
+        scrollAlignment: 0.5, // Center the target in scroll view
+        skipInvisibleTargets: true, // Skip targets that can't be shown
         child: const MyHomePage(title: 'Hotspot Demo Home Page'),
       ),
     );
@@ -86,33 +89,251 @@ class _MyHomePageState extends State<MyHomePage> {
           ),
         ],
       ),
-      body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text(
-              'You have smashed the button this many times:',
+      body: ListView(
+        children: <Widget>[
+          Center(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: <Widget>[
+                const SizedBox(height: 20),
+                const Text(
+                  'You have smashed the button this many times:',
+                ),
+                Text(
+                  '$_counter',
+                  style: Theme.of(context).textTheme.headlineMedium,
+                ).withHotspot(
+                  order: 2,
+                  title: 'Count It!',
+                  text:
+                      'This is the number of times you\'ve smashed the like button',
+                ),
+                const SizedBox(height: 30),
+
+                // Add a button to navigate to the list example
+                ElevatedButton(
+                  onPressed: () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute(
+                        builder: (context) => const ListExamplePage(),
+                      ),
+                    );
+                  },
+                  child: const Text('Go to List Example'),
+                ).withHotspot(
+                  order: 3,
+                  title: 'List Example',
+                  text:
+                      'Click here to see how hotspot works with scrollable lists',
+                ),
+
+                const SizedBox(height: 30),
+                FloatingActionButton(
+                  onPressed: _incrementCounter,
+                  tooltip: 'Like',
+                  child: const Icon(Icons.thumb_up),
+                ).withHotspot(
+                  order: 5, // Changed from 3 to 5 to accommodate the new button
+                  title: 'Smash It!',
+                  text: 'Smash this button after the tour.',
+                ),
+              ],
             ),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ).withHotspot(
-              order: 2,
-              title: 'Count It!',
-              text:
-                  'This is the number of times you\'ve smashed the like button',
-            ),
-          ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class ListExamplePage extends StatelessWidget {
+  const ListExamplePage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return HotspotProvider(
+      hotspotShapeBorder: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(8),
+        side: const BorderSide(color: Colors.orange, width: 2),
+      ),
+      autoScroll: true,
+      scrollAlignment: 0.5, // Center the target in scroll view
+      skipInvisibleTargets: true, // Skip targets that can't be shown
+      scrollDuration: const Duration(
+          milliseconds: 800), // Longer duration for more visible scrolling
+      scrollTimeout: const Duration(seconds: 3), // Longer timeout
+      child: const ListExamplePageView(),
+    );
+  }
+}
+
+class ListExamplePageView extends StatefulWidget {
+  const ListExamplePageView({Key? key}) : super(key: key);
+
+  @override
+  State<ListExamplePageView> createState() => _ListExamplePageViewState();
+}
+
+class _ListExamplePageViewState extends State<ListExamplePageView> {
+  // Generate a list of 50 items for better demonstration of scrolling
+  final List<String> items = List.generate(50, (index) => 'Item ${index + 1}');
+  final ScrollController _scrollController = ScrollController();
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
+  void initState() {
+    super.initState();
+
+    // Start the list tour after everything is fully rendered
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      // Ensure we're at the top of the list when starting
+      _scrollController.jumpTo(0);
+
+      // Small delay to ensure the list is fully rendered
+      Future.delayed(const Duration(milliseconds: 500), () {
+        HotspotProvider.of(context).startFlow('list');
+      });
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Scrolling Example').withHotspot(
+          flow: 'list',
+          order: 1,
+          title: 'Scrollable List',
+          text:
+              'This example shows how hotspot automatically scrolls to show items',
         ),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.play_arrow),
+            onPressed: () {
+              // Ensure we're at the top of the list when restarting
+              _scrollController.animateTo(
+                0,
+                duration: const Duration(milliseconds: 300),
+                curve: Curves.easeOut,
+              );
+
+              Future.delayed(const Duration(milliseconds: 350), () {
+                HotspotProvider.of(context).startFlow('list');
+              });
+            },
+          ).withHotspot(
+            flow: 'list',
+            order: 2,
+            title: 'Restart Tour',
+            text: 'Click here to restart the scrolling demonstration',
+          ),
+        ],
+      ),
+      body: ListView.builder(
+        controller: _scrollController,
+        padding: const EdgeInsets.all(16),
+        itemCount: items.length,
+        itemBuilder: (context, index) {
+          // Add hotspots to specific items with more spacing between them
+          if (index == 0) {
+            return Card(
+              elevation: 2,
+              child: ListTile(
+                title: Text(items[index],
+                    style: const TextStyle(fontWeight: FontWeight.bold)),
+                leading: const Icon(Icons.star, color: Colors.amber),
+                subtitle:
+                    const Text('This is the first item in our scrollable list'),
+              ),
+            ).withHotspot(
+              flow: 'list',
+              order: 3,
+              title: 'First Item',
+              text: 'This is the first item in our list',
+            );
+          } else if (index == 10) {
+            return Card(
+              elevation: 2,
+              color: Colors.lightBlue.withOpacity(0.1),
+              child: ListTile(
+                title: Text(items[index],
+                    style: const TextStyle(fontWeight: FontWeight.bold)),
+                leading: const Icon(Icons.favorite, color: Colors.red),
+                subtitle: const Text(
+                    'This item should scroll into view automatically'),
+              ),
+            ).withHotspot(
+              flow: 'list',
+              order: 4,
+              title: 'Item #10',
+              text: 'The list should have scrolled down to show this item',
+            );
+          } else if (index == 15) {
+            return Card(
+              elevation: 2,
+              color: Colors.amber.withOpacity(0.1),
+              child: ListTile(
+                title: Text(items[index],
+                    style: const TextStyle(fontWeight: FontWeight.bold)),
+                leading: const Icon(Icons.lightbulb, color: Colors.amber),
+                subtitle: const Text('This is much farther down the list'),
+              ),
+            ).withHotspot(
+              flow: 'list',
+              order: 5,
+              title: 'Item #16',
+              text: 'Notice how the page automatically scrolls to show items',
+            );
+          } else if (index == 40) {
+            return Card(
+              elevation: 2,
+              color: Colors.green.withOpacity(0.1),
+              child: ListTile(
+                title: Text(items[index],
+                    style: const TextStyle(fontWeight: FontWeight.bold)),
+                leading: const Icon(Icons.check_circle, color: Colors.green),
+                subtitle: const Text('This is near the end of our list!'),
+              ),
+            ).withHotspot(
+              flow: 'list',
+              order: 6,
+              title: 'Item #40',
+              text: 'We\'re nearing the end of the list tour!',
+            );
+          } else {
+            return ListTile(
+              title: Text(items[index]),
+            );
+          }
+        },
       ),
       floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Like',
-        child: const Icon(Icons.thumb_up),
+        onPressed: () {
+          // First ensure we're at the top of the list
+          _scrollController.animateTo(
+            0,
+            duration: const Duration(milliseconds: 300),
+            curve: Curves.easeOut,
+          );
+
+          // Then start the tour after scrolling completes
+          Future.delayed(const Duration(milliseconds: 350), () {
+            HotspotProvider.of(context).startFlow('list');
+          });
+        },
+        tooltip: 'Start Tour',
+        child: const Icon(Icons.play_arrow),
       ).withHotspot(
-        order: 3,
-        title: 'Smash It!',
-        text: 'Smash this button after the tour.',
+        flow: 'list',
+        order: 7,
+        title: 'Start Tour',
+        text: 'Click this button to restart the list tour',
       ),
     );
   }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -290,6 +290,22 @@ class _ListExamplePageViewState extends State<ListExamplePageView> {
               title: 'Item #16',
               text: 'Notice how the page automatically scrolls to show items',
             );
+          } else if (index == 18) {
+            return Card(
+              elevation: 2,
+              color: Colors.amber.withOpacity(0.1),
+              child: ListTile(
+                title: Text(items[index],
+                    style: const TextStyle(fontWeight: FontWeight.bold)),
+                leading: const Icon(Icons.lightbulb, color: Colors.amber),
+                subtitle: const Text('This is much farther down the list'),
+              ),
+            ).withHotspot(
+              flow: 'list',
+              order: 8,
+              title: 'Item #18',
+              text: 'Notice how the page automatically scrolls to show items',
+            );
           } else if (index == 40) {
             return Card(
               elevation: 2,

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -81,23 +81,23 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.1.1"
+    version: "0.1.3"
   leak_tracker:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.4"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -126,18 +126,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.15.0"
   nested:
     dependency: transitive
     description:
@@ -211,10 +211,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.7.2"
   vector_math:
     dependency: transitive
     description:
@@ -227,10 +227,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.1"
+    version: "14.2.5"
 sdks:
   dart: ">=3.4.3 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/lib/src/callout_tail_painter.dart
+++ b/lib/src/callout_tail_painter.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/widgets.dart';
 
 class CalloutTailPainter extends CustomPainter {
-  /// Paints the callout tail for [HotspotProvider] based on a [Rect] bounds
+  /// Paints the callout tail for [HotspotProvider] based on a [Rect] bounds.
   CalloutTailPainter({
     required this.tailBounds,
     required this.color,
@@ -28,6 +28,7 @@ class CalloutTailPainter extends CustomPainter {
       ..lineTo(tailBounds.centerLeft.dx, tailBounds.centerLeft.dy)
       ..lineTo(tailBounds.topCenter.dx, tailBounds.topCenter.dy);
 
+    // Draw the fill
     canvas.drawPath(tailPath, backgroundPaint);
   }
 

--- a/lib/src/hotspot_painter.dart
+++ b/lib/src/hotspot_painter.dart
@@ -6,7 +6,14 @@ class HotspotPainter extends CustomPainter {
     required this.hotspotBounds,
     required this.skrimColor,
     required this.shapeBorder,
-  });
+    this.hotspotBorderColor,
+    this.hotspotBorderWidth,
+  }) {
+    if (shapeBorder is OutlinedBorder) {
+      hotspotBorderColor ??= (shapeBorder as OutlinedBorder).side.color;
+      hotspotBorderWidth ??= (shapeBorder as OutlinedBorder).side.width;
+    }
+  }
 
   /// The target to highlight with a hotspot.
   final Rect hotspotBounds;
@@ -15,6 +22,12 @@ class HotspotPainter extends CustomPainter {
   /// between the hotspot callout and the view. Provides
   /// hotspot cutouts that surround the appropriate [HotspotTarget].
   final Color skrimColor;
+
+  /// The color of the hotspot border. If null, value is derived from the [shapeBorder] if it is an [OutlinedBorder].
+  Color? hotspotBorderColor;
+
+  /// The width of the hotspot border. If null, value is derived from the [shapeBorder] if it is an [OutlinedBorder].
+  num? hotspotBorderWidth;
 
   /// Override the convenience [radius] with a custom [ShapeBorder]
   ///
@@ -37,11 +50,25 @@ class HotspotPainter extends CustomPainter {
     final path = Path.combine(PathOperation.difference, skrimPath, hotspotPath);
 
     canvas.drawPath(path, skrimPaint);
+
+    // Draw the border if borderColor and borderWidth are set
+    if (hotspotBorderColor != null &&
+        hotspotBorderWidth != null &&
+        hotspotBorderWidth! > 0) {
+      final borderPaint = Paint()
+        ..style = PaintingStyle.stroke
+        ..color = hotspotBorderColor!
+        ..strokeWidth = hotspotBorderWidth!.toDouble();
+
+      canvas.drawPath(hotspotPath, borderPaint);
+    }
   }
 
   @override
   bool shouldRepaint(HotspotPainter old) =>
       hotspotBounds != old.hotspotBounds ||
       skrimColor != old.skrimColor ||
-      shapeBorder != old.shapeBorder;
+      shapeBorder != old.shapeBorder ||
+      hotspotBorderColor != old.hotspotBorderColor ||
+      hotspotBorderWidth != old.hotspotBorderWidth;
 }

--- a/lib/src/hotspot_provider.dart
+++ b/lib/src/hotspot_provider.dart
@@ -352,9 +352,14 @@ class HotspotProviderState extends State<HotspotProvider>
                 return CustomPaint(
                   painter: HotspotPainter(
                     hotspotBounds: t!,
-                    hotspotBorderColor: widget.hotspotBorderColor,
-                    hotspotBorderWidth: widget.hotspotBorderWidth,
-                    shapeBorder: widget.hotspotShapeBorder,
+                    hotspotBorderColor:
+                        currentTarget.widget.hotspotBorderColor ??
+                            widget.hotspotBorderColor,
+                    hotspotBorderWidth:
+                        currentTarget.widget.hotspotBorderWidth ??
+                            widget.hotspotBorderWidth,
+                    shapeBorder: currentTarget.widget.hotspotShape ??
+                        widget.hotspotShapeBorder,
                     skrimColor: widget.skrimColor ??
                         Theme.of(context).colorScheme.scrim.withOpacity(0.4),
                   ),

--- a/lib/src/hotspot_provider.dart
+++ b/lib/src/hotspot_provider.dart
@@ -96,6 +96,8 @@ class HotspotProvider extends StatefulWidget {
     this.bodyPadding = const EdgeInsets.all(16),
     this.dismissibleSkrim = true,
     this.skrimCurve = Curves.easeOutExpo,
+    this.hotspotBorderColor,
+    this.hotspotBorderWidth,
   }) : super(key: key);
 
   /// The child which contains multiple [HotspotTarget] in the tree.
@@ -149,6 +151,12 @@ class HotspotProvider extends StatefulWidget {
 
   /// Curve for the skrim.
   final Curve skrimCurve;
+
+  /// Border color of the hotspot. if null, value is derived from the [hotspotShapeBorder] if it is an [OutlinedBorder].
+  final Color? hotspotBorderColor;
+
+  /// Width of the border of the hotspot. if null, value is derived from the [hotspotShapeBorder] if it is an [OutlinedBorder].
+  final num? hotspotBorderWidth;
 
   /// Retreive the ancestor [HotspotProvider] for the purpose of performing actions.
   static HotspotProviderState of(BuildContext context) =>
@@ -344,6 +352,8 @@ class HotspotProviderState extends State<HotspotProvider>
                 return CustomPaint(
                   painter: HotspotPainter(
                     hotspotBounds: t!,
+                    hotspotBorderColor: widget.hotspotBorderColor,
+                    hotspotBorderWidth: widget.hotspotBorderWidth,
                     shapeBorder: widget.hotspotShapeBorder,
                     skrimColor: widget.skrimColor ??
                         Theme.of(context).colorScheme.scrim.withOpacity(0.4),

--- a/lib/src/hotspot_provider.dart
+++ b/lib/src/hotspot_provider.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:hotspot/hotspot.dart';
 import 'package:provider/provider.dart';
 
@@ -98,6 +99,11 @@ class HotspotProvider extends StatefulWidget {
     this.skrimCurve = Curves.easeOutExpo,
     this.hotspotBorderColor,
     this.hotspotBorderWidth,
+    this.autoScroll = true,
+    this.scrollDuration = const Duration(milliseconds: 500),
+    this.scrollAlignment = 0.5,
+    this.scrollTimeout = const Duration(seconds: 2),
+    this.skipInvisibleTargets = true,
   }) : super(key: key);
 
   /// The child which contains multiple [HotspotTarget] in the tree.
@@ -158,6 +164,21 @@ class HotspotProvider extends StatefulWidget {
   /// Width of the border of the hotspot. if null, value is derived from the [hotspotShapeBorder] if it is an [OutlinedBorder].
   final num? hotspotBorderWidth;
 
+  /// Whether to automatically scroll to targets that are not visible in the viewport.
+  final bool autoScroll;
+
+  /// Duration for the scroll animation.
+  final Duration scrollDuration;
+
+  /// Alignment used when scrolling to position targets (0.0 for top, 0.5 for center, 1.0 for bottom).
+  final double scrollAlignment;
+
+  /// Timeout for scrolling attempts before moving to the next target.
+  final Duration scrollTimeout;
+
+  /// Whether to automatically skip targets that cannot be scrolled into view.
+  final bool skipInvisibleTargets;
+
   /// Retreive the ancestor [HotspotProvider] for the purpose of performing actions.
   static HotspotProviderState of(BuildContext context) =>
       Provider.of<HotspotProviderState>(context, listen: false);
@@ -182,13 +203,34 @@ class HotspotProviderState extends State<HotspotProvider>
   /// put the focus back where it was.
   FocusNode? _lastFocusNode;
 
+  /// Track whether we're currently in a scrolling operation
+  bool _isScrolling = false;
+
+  /// Animation controller for position updates
+  late AnimationController _positionAnimationController;
+
+  @override
+  void initState() {
+    super.initState();
+    _positionAnimationController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 100),
+    );
+  }
+
+  @override
+  void dispose() {
+    _positionAnimationController.dispose();
+    super.dispose();
+  }
+
   /// Convenience getter for the current flow sorted by order.
   List<HotspotTargetState> get currentFlow =>
       _targets.where((e) => e.widget.flow == _flow).toList()
         ..sort((a, b) => a.widget.order.compareTo(b.widget.order));
 
   /// Initiate a hotspot flow
-  void startFlow([String flow = 'main']) {
+  Future<void> startFlow([String flow = 'main']) async {
     /// Dismiss keyboard if open
     _lastFocusNode = FocusManager.instance.primaryFocus;
     _lastFocusNode?.unfocus();
@@ -208,15 +250,28 @@ class HotspotProviderState extends State<HotspotProvider>
         _visible = true;
       }
     });
+
+    // Give the UI a moment to render before attempting to scroll
+    if (widget.autoScroll && currentFlow.isNotEmpty) {
+      // Use a small delay to ensure everything is properly laid out
+      await Future.delayed(const Duration(milliseconds: 200));
+      await _ensureTargetVisibility(currentFlow[_index]);
+    }
   }
 
   /// Called when tapping the next button.
   /// Can be called externally.
-  void next() {
+  Future<void> next() async {
     _pruneUnmountedTargets();
 
     if (_index + 1 < currentFlow.length) {
       setState(() => _index++);
+
+      // Ensure the next target is visible if auto-scroll is enabled
+      if (widget.autoScroll) {
+        await Future.delayed(const Duration(milliseconds: 100));
+        await _ensureTargetVisibility(currentFlow[_index]);
+      }
     } else {
       dismiss();
     }
@@ -224,11 +279,17 @@ class HotspotProviderState extends State<HotspotProvider>
 
   /// Called when tapping the previous button.
   /// Can be called externally.
-  void previous() {
+  Future<void> previous() async {
     _pruneUnmountedTargets();
 
     if (_index >= 1) {
       setState(() => _index--);
+
+      // Ensure the previous target is visible if auto-scroll is enabled
+      if (widget.autoScroll) {
+        await Future.delayed(const Duration(milliseconds: 100));
+        await _ensureTargetVisibility(currentFlow[_index]);
+      }
     } else {
       dismiss();
     }
@@ -258,6 +319,240 @@ class HotspotProviderState extends State<HotspotProvider>
   void _handleNewTarget(HotspotTargetState e) {
     _targets.add(e);
     _pruneUnmountedTargets();
+  }
+
+  /// Checks if a target is visible in the viewport
+  bool _isTargetVisible(HotspotTargetState target) {
+    if (!target.mounted) return false;
+
+    try {
+      // Get the global paint bounds of the target
+      final targetBounds = target.globalPaintBounds;
+
+      // Get the viewport bounds
+      final viewportBounds = Rect.fromLTWH(
+        0,
+        0,
+        MediaQuery.of(context).size.width,
+        MediaQuery.of(context).size.height,
+      );
+
+      if (HotspotProvider.log) {
+        debugPrint(
+            '[Hotspot] checking visibility: ${target.widget.flow}:${target.widget.order}');
+        debugPrint(
+            '[Hotspot] target bounds: $targetBounds, viewport: $viewportBounds');
+      }
+
+      // Consider target visible if it's at least 30% visible in the viewport
+      final intersection = targetBounds.intersect(viewportBounds);
+      final visibleArea = intersection.width * intersection.height;
+      final targetArea = targetBounds.width * targetBounds.height;
+
+      final isVisible =
+          !intersection.isEmpty && (visibleArea / targetArea) > 0.3;
+
+      if (HotspotProvider.log) {
+        debugPrint(
+            '[Hotspot] target visibility: $isVisible (${(visibleArea / targetArea * 100).toStringAsFixed(1)}%)');
+      }
+
+      return isVisible;
+    } catch (e) {
+      debugPrint('[Hotspot] Error checking visibility: $e');
+      return false;
+    }
+  }
+
+  /// Attempts to scroll a target into view
+  Future<bool> _scrollTargetIntoView(HotspotTargetState target) async {
+    if (!target.mounted) return false;
+
+    if (HotspotProvider.log) {
+      debugPrint(
+          '[Hotspot] attempting to scroll to target: ${target.widget.flow}:${target.widget.order}');
+    }
+
+    try {
+      // Try to scroll the target into view with a timeout
+      return await Future.any([
+        _scrollToTarget(target),
+        Future.delayed(widget.scrollTimeout, () {
+          if (HotspotProvider.log) {
+            debugPrint('[Hotspot] scroll timeout reached');
+          }
+          return false;
+        })
+      ]);
+    } catch (e) {
+      if (HotspotProvider.log) {
+        debugPrint('[Hotspot] error scrolling to target: $e');
+      }
+      return false;
+    }
+  }
+
+  /// Performs the actual scrolling operation
+  Future<bool> _scrollToTarget(HotspotTargetState target) async {
+    try {
+      if (HotspotProvider.log) {
+        debugPrint(
+            '[Hotspot] scrolling to target: ${target.widget.flow}:${target.widget.order}');
+      }
+
+      _isScrolling = true;
+
+      // Find the actual scrollable ancestor
+      final ScrollableState? scrollable = Scrollable.of(target.context);
+
+      if (scrollable == null) {
+        if (HotspotProvider.log) {
+          debugPrint('[Hotspot] no scrollable found for target');
+        }
+        _isScrolling = false;
+        return _isTargetVisible(target);
+      }
+
+      // Get the initial position to detect if scrolling actually occurred
+      final initialPosition = scrollable.position.pixels;
+
+      // Try more directly to control the scrolling
+      final RenderObject? targetRenderObject =
+          target.context.findRenderObject();
+
+      if (targetRenderObject == null) {
+        _isScrolling = false;
+        return _isTargetVisible(target);
+      }
+
+      final RenderAbstractViewport? viewport =
+          RenderAbstractViewport.of(targetRenderObject);
+
+      if (viewport == null) {
+        if (HotspotProvider.log) {
+          debugPrint('[Hotspot] no viewport found for target');
+        }
+        _isScrolling = false;
+        return _isTargetVisible(target);
+      }
+
+      // Calculate the scroll offset needed
+      await scrollable.position.ensureVisible(
+        targetRenderObject,
+        alignment: widget.scrollAlignment,
+        duration: widget.scrollDuration,
+        curve: widget.curve,
+      );
+
+      // Check if scrolling actually occurred
+      final didScroll = scrollable.position.pixels != initialPosition;
+
+      if (didScroll) {
+        // Wait for layout to settle after scrolling
+        await Future.delayed(const Duration(milliseconds: 300));
+
+        // Force a rebuild to update the hotspot position
+        if (mounted) {
+          // Reset animation controller
+          _positionAnimationController.reset();
+
+          // Start the animation to update position smoothly
+          _positionAnimationController.forward();
+
+          setState(() {
+            // Just trigger a rebuild to recalculate target positions
+          });
+        }
+      }
+
+      // Wait a bit more to ensure animations complete
+      await Future.delayed(const Duration(milliseconds: 100));
+
+      _isScrolling = false;
+
+      // Check if target is now visible
+      final isVisible = _isTargetVisible(target);
+      if (HotspotProvider.log) {
+        debugPrint('[Hotspot] after scrolling, target visibility: $isVisible');
+      }
+      return isVisible;
+    } catch (e) {
+      debugPrint('[Hotspot] error in scroll operation: $e');
+      _isScrolling = false;
+
+      // Fallback to standard method if custom approach fails
+      try {
+        await Scrollable.ensureVisible(
+          target.context,
+          alignment: widget.scrollAlignment,
+          duration: widget.scrollDuration,
+          curve: widget.curve,
+        );
+
+        // Wait for layout to settle after scrolling
+        await Future.delayed(const Duration(milliseconds: 300));
+
+        // Force a rebuild to update the hotspot position
+        if (mounted) {
+          // Reset animation controller
+          _positionAnimationController.reset();
+
+          // Start the animation to update position smoothly
+          _positionAnimationController.forward();
+
+          setState(() {
+            // Just trigger a rebuild to recalculate target positions
+          });
+        }
+
+        await Future.delayed(const Duration(milliseconds: 100));
+
+        return _isTargetVisible(target);
+      } catch (e) {
+        debugPrint('[Hotspot] fallback scroll method also failed: $e');
+        return _isTargetVisible(target);
+      }
+    }
+  }
+
+  /// Ensures target visibility, skipping to next target if needed
+  Future<void> _ensureTargetVisibility(HotspotTargetState target) async {
+    if (!target.mounted) return;
+
+    if (HotspotProvider.log) {
+      debugPrint(
+          '[Hotspot] ensuring visibility of target: ${target.widget.flow}:${target.widget.order}');
+    }
+
+    if (!_isTargetVisible(target)) {
+      final scrolled = await _scrollTargetIntoView(target);
+
+      // Ensure we force a rebuild after scrolling to update positions
+      if (scrolled && mounted) {
+        // Reset animation controller
+        _positionAnimationController.reset();
+
+        // Start the animation to update position smoothly
+        _positionAnimationController.forward();
+
+        setState(() {
+          // This will trigger a rebuild with the latest positions
+        });
+      }
+
+      // If target can't be scrolled into view and auto-skip is enabled, go to next target
+      if (!scrolled &&
+          widget.skipInvisibleTargets &&
+          _index + 1 < currentFlow.length) {
+        if (HotspotProvider.log) {
+          debugPrint(
+              '[Hotspot] target not visible after scrolling, skipping to next target');
+        }
+        await next();
+      }
+    } else if (HotspotProvider.log) {
+      debugPrint('[Hotspot] target already visible, no need to scroll');
+    }
   }
 
   Color get bg =>
@@ -298,11 +593,15 @@ class HotspotProviderState extends State<HotspotProvider>
                     } else {
                       return PaintBoundsBuilder(
                         builder: (context, paintBounds) {
+                          // Always get fresh position data when building
+                          final targetBounds =
+                              _getUpdatedTargetBounds(currentTarget);
+
                           final delegate = CalloutLayoutDelegate(
                             tailSize: widget.tailSize,
                             tailInsets: widget.tailInsets,
                             paintBounds: paintBounds,
-                            targetBounds: currentTarget.globalPaintBounds,
+                            targetBounds: targetBounds,
                             hotspotPadding: widget.padding,
                             bodyMargin: widget.bodyMargin,
                             bodyWidth: widget.bodyWidth,
@@ -326,6 +625,26 @@ class HotspotProviderState extends State<HotspotProvider>
         ),
       ),
     );
+  }
+
+  /// Get fresh target bounds, ensuring we have the most up-to-date position
+  Rect _getUpdatedTargetBounds(HotspotTargetState target) {
+    if (!target.mounted) {
+      return Rect.zero;
+    }
+
+    try {
+      // Force a fresh calculation of the global paint bounds
+      final RenderBox renderBox =
+          target.context.findRenderObject() as RenderBox;
+      final position = renderBox.localToGlobal(Offset.zero);
+      final size = renderBox.size;
+      return Rect.fromLTWH(position.dx, position.dy, size.width, size.height);
+    } catch (e) {
+      debugPrint('[Hotspot] Error getting updated bounds: $e');
+      // Fall back to the original method if there's an error
+      return target.globalPaintBounds;
+    }
   }
 
   /// Build the hotspot and callout

--- a/lib/src/hotspot_target.dart
+++ b/lib/src/hotspot_target.dart
@@ -75,6 +75,9 @@ class HotspotTarget extends StatefulWidget {
     required this.child,
     this.hotspotSize,
     this.hotspotOffset = Offset.zero,
+    this.hotspotShape,
+    this.hotspotBorderWidth,
+    this.hotspotBorderColor,
   }) : super(key: key);
 
   /// Combines multiple hotspot targets into a single group.
@@ -101,6 +104,15 @@ class HotspotTarget extends StatefulWidget {
 
   /// Override the hotspot center with a custom offset.
   final Offset hotspotOffset;
+
+  /// The shape of the hotspot. Has a higher priority than the corresponding shape in [HotspotProvider].
+  final ShapeBorder? hotspotShape;
+
+  /// The width of the hotspot border. Has a higher priority than the corresponding width in [HotspotProvider].
+  final num? hotspotBorderWidth;
+
+  /// The color of the hotspot border. Has a higher priority than the corresponding color in [HotspotProvider].
+  final Color? hotspotBorderColor;
 
   @override
   HotspotTargetState createState() => HotspotTargetState();

--- a/lib/src/hotspot_target.dart
+++ b/lib/src/hotspot_target.dart
@@ -125,10 +125,31 @@ class HotspotTargetState extends State<HotspotTarget> {
     super.didChangeDependencies();
   }
 
+  @override
+  void didUpdateWidget(HotspotTarget oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // Notify HotspotProvider if anything changes
+    if (oldWidget.flow != widget.flow || oldWidget.order != widget.order) {
+      HotspotNotification(target: this).dispatch(context);
+    }
+  }
+
   /// Convenience getter to find the global paint bounds of this [HotspotTarget]
-  Rect get globalPaintBounds =>
-      (context.findRenderObject() as RenderBox).paintBounds.shift(
-          (context.findRenderObject() as RenderBox).localToGlobal(Offset.zero));
+  Rect get globalPaintBounds {
+    if (!mounted) return Rect.zero;
+
+    try {
+      final RenderBox renderBox = context.findRenderObject() as RenderBox;
+      if (!renderBox.hasSize) return Rect.zero;
+
+      final position = renderBox.localToGlobal(Offset.zero);
+      final size = renderBox.size;
+      return Rect.fromLTWH(position.dx, position.dy, size.width, size.height);
+    } catch (e) {
+      debugPrint('[Hotspot] Error calculating globalPaintBounds: $e');
+      return Rect.zero;
+    }
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/paint_bounds_builder.dart
+++ b/lib/src/paint_bounds_builder.dart
@@ -18,13 +18,28 @@ class _PaintBoundsBuilderState extends State<PaintBoundsBuilder> {
 
   @override
   void initState() {
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      setState(() {
-        _paintBounds ??= (context.findRenderObject() as RenderBox).paintBounds;
-      });
-    });
-
+    _scheduleBoundsUpdate();
     super.initState();
+  }
+
+  @override
+  void didUpdateWidget(PaintBoundsBuilder oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // Check for updates when the widget changes
+    _scheduleBoundsUpdate();
+  }
+
+  void _scheduleBoundsUpdate() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+
+      final RenderObject? renderObj = context.findRenderObject();
+      if (renderObj != null && renderObj is RenderBox && renderObj.hasSize) {
+        setState(() {
+          _paintBounds = renderObj.paintBounds;
+        });
+      }
+    });
   }
 
   @override

--- a/lib/src/with_hotspot_x.dart
+++ b/lib/src/with_hotspot_x.dart
@@ -11,6 +11,9 @@ extension WithHotspotX on Widget {
     Widget? icon,
     Size? hotspotSize,
     Offset hotspotOffset = Offset.zero,
+    ShapeBorder? hotspotShape,
+    num? hotspotBorderWidth,
+    Color? hotspotBorderColor,
   }) {
     return Builder(
       builder: (context) {
@@ -22,6 +25,9 @@ extension WithHotspotX on Widget {
           hotspotSize: hotspotSize,
           hotspotOffset: hotspotOffset,
           order: order,
+          hotspotBorderColor: hotspotBorderColor,
+          hotspotBorderWidth: hotspotBorderWidth,
+          hotspotShape: hotspotShape,
           calloutBody: Row(
             children: [
               if (icon != null) ...[

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -63,18 +63,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.4"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -95,18 +95,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.15.0"
   nested:
     dependency: transitive
     description:
@@ -180,10 +180,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.7.2"
   vector_math:
     dependency: transitive
     description:
@@ -196,10 +196,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.1"
+    version: "14.2.5"
 sdks:
   dart: ">=3.4.3 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"


### PR DESCRIPTION
Include functionality to add borders around the hotspot callout target.

Needed for cases like the picture below:
<img width="511" alt="Screenshot 2024-10-02 at 3 42 05 PM" src="https://github.com/user-attachments/assets/5c3112b9-a1ee-416c-991e-2ffb433e9759">

